### PR TITLE
redirect to auth callback if session / realm aren't found in memory

### DIFF
--- a/caddyfile.go
+++ b/caddyfile.go
@@ -33,12 +33,19 @@ func parseCaddyfileGlobalOption(d *caddyfile.Dispenser, _ any) (any, error) {
 				if d.NextArg() {
 					return nil, d.ArgErr()
 				}
+			case "cookie_name":
+				if d.NextArg() {
+					dpApp.CookieName = d.Val()
+				}
+				if d.NextArg() {
+					return nil, d.ArgErr()
+				}
 			case "realm":
 				realmBuilder := NewRealmBuilder()
 
 				if d.NextArg() {
 					realmBuilder.Name(d.Val())
-					//ag.Ref = d.Val()
+					// ag.Ref = d.Val()
 				}
 
 				for subNesting := d.Nesting(); d.NextBlock(subNesting); {

--- a/module_app.go
+++ b/module_app.go
@@ -3,6 +3,7 @@ package caddydiscord
 import (
 	"encoding/hex"
 	"fmt"
+
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig/httpcaddyfile"
 	"golang.org/x/oauth2"
@@ -15,8 +16,8 @@ var (
 )
 
 const (
-	moduleName = "discord"
-	cookieName = "_DISCORDCADDY"
+	moduleName        = "discord"
+	defaultCookieName = "_DISCORDCADDY"
 )
 
 func init() {
@@ -29,6 +30,7 @@ type DiscordPortalApp struct {
 	ClientSecret string        `json:"clientSecret"`
 	RedirectURL  string        `json:"redirectURL"`
 	Realms       RealmRegistry `json:"realms"`
+	CookieName   string        `json:"cookieName"`
 	oauthConfig  *oauth2.Config
 	Key          string `json:"key,omitempty"`
 }
@@ -65,7 +67,7 @@ func (d DiscordPortalApp) Validate() error {
 	}
 
 	if d.RedirectURL == "" {
-		return fmt.Errorf("redirect URL has not bee configured")
+		return fmt.Errorf("redirect URL has not been configured")
 	}
 
 	return nil

--- a/module_callback.go
+++ b/module_callback.go
@@ -58,7 +58,7 @@ func (s *DiscordAuthPlugin) Provision(ctx caddy.Context) error {
 	s.Realms = &app.Realms
 
 	s.CookieName = app.CookieName
-	if s.CookieName != "" {
+	if s.CookieName == "" {
 		// Use default cookie name if none provided
 		s.CookieName = defaultCookieName
 	}
@@ -137,7 +137,7 @@ func (d DiscordAuthPlugin) ServeHTTP(w http.ResponseWriter, r *http.Request, _ c
 	identity, err := client.FetchCurrentUser()
 	if err != nil || len(identity.ID) == 0 {
 		// Unable to resolve realm
-		http.Error(w, "Failed to resolve Discord User", http.StatusInternalServerError)
+		http.Redirect(w, r, token.RedirectURI, http.StatusFound)
 		return err
 	}
 
@@ -164,7 +164,6 @@ func (d DiscordAuthPlugin) ServeHTTP(w http.ResponseWriter, r *http.Request, _ c
 		// User failed realm checks
 		// http.Error(w, "You do not have access to this", http.StatusForbidden)
 		http.Redirect(w, r, token.RedirectURI, http.StatusFound)
-
 		return nil
 	}
 	// Re-validate user through OAuth2 flow every 16 hours

--- a/module_entrypoint.go
+++ b/module_entrypoint.go
@@ -52,7 +52,7 @@ type ProtectorPlugin struct {
 
 // Authenticate implements caddyhttp.MiddlewareHandler.
 func (e ProtectorPlugin) Authenticate(w http.ResponseWriter, r *http.Request) (caddyauth.User, bool, error) {
-	existingSession, _ := r.Cookie(fmt.Sprintf("%s_%s", defaultCookieName, e.Realm))
+	existingSession, _ := r.Cookie(fmt.Sprintf("%s_%s", e.CookieName, e.Realm))
 
 	// Handle passing through signed token over to support multiple domains.
 	if existingSession == nil && r.URL.Query().Has("DISCO_PASSTHROUGH") && r.URL.Query().Has("DISCO_REALM") {
@@ -64,7 +64,7 @@ func (e ProtectorPlugin) Authenticate(w http.ResponseWriter, r *http.Request) (c
 		r.URL.RawQuery = q.Encode()
 
 		cookie := &http.Cookie{
-			Name:     fmt.Sprintf("%s_%s", defaultCookieName, realm),
+			Name:     fmt.Sprintf("%s_%s", e.CookieName, realm),
 			Value:    signedToken,
 			Expires:  time.Now().Add(time.Hour * 16),
 			HttpOnly: true,

--- a/module_entrypoint.go
+++ b/module_entrypoint.go
@@ -124,7 +124,7 @@ func (p *ProtectorPlugin) Provision(ctx caddy.Context) error {
 	p.OAuthConfig = app.getOAuthConfig()
 
 	p.CookieName = app.CookieName
-	if p.CookieName != "" {
+	if p.CookieName == "" {
 		// Use default cookie name if none provided
 		p.CookieName = defaultCookieName
 	}


### PR DESCRIPTION
**Problem**
If the server restarts after a user authenticates, when they revisit a protected page they'll be greeted with an unfriendly 401 unless their cookie has already expired. The workaround for this is to have a user clear their cookies, but this is less than ideal.

**Solution**
When a user provides a token with an invalid session or realm, redirect them to the Discord authentication page instead of completely blocking them out.

**Additional changes**
While I was poking around, I figured I'd add configuration for the name of the cookie that gets set in the browser by this plugin as allowing only the default exposes an implementation detail, which is better avoided where possible.

EDIT: Still not working as intended, following up with maintainer